### PR TITLE
fix(test): terminate mock servers on stop

### DIFF
--- a/tests/helpers/mock_server.lua
+++ b/tests/helpers/mock_server.lua
@@ -33,8 +33,13 @@ function M.start(fixture)
   assert.is_nil(state.exit, state.stderr)
   state.port = state.records[1].port
   function state:stop()
-    if not self.exit then self.process:kill(15) end
-    vim.wait(2000, function() return self.exit ~= nil end)
+    if self.exit then return true end
+    self.process:kill(15)
+    if vim.wait(2000, function() return self.exit ~= nil end) then
+      return true
+    end
+    self.process:kill(9)
+    return vim.wait(2000, function() return self.exit ~= nil end)
   end
   return state
 end

--- a/tests/integration/mock_server_spec.lua
+++ b/tests/integration/mock_server_spec.lua
@@ -1,0 +1,9 @@
+local mock_server = require("tests.helpers.mock_server")
+
+describe("mock server process cleanup", function()
+  it("terminates the mock server process on stop", function()
+    local server = mock_server.start("tests/fixtures/openai/stream.json")
+    assert(server:stop(), "stop must terminate the mock server process")
+    assert.is_not_nil(server.exit, "stop must reap the mock server process")
+  end)
+end)

--- a/tests/mock_openai.py
+++ b/tests/mock_openai.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import signal
 import sys
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -105,12 +104,6 @@ class Handler(BaseHTTPRequestHandler):
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 record({"type": "ready", "port": server.server_address[1]})
 
-
-def stop(_signum, _frame):
-    server.shutdown()
-
-
-signal.signal(signal.SIGTERM, stop)
 try:
     server.serve_forever()
 finally:


### PR DESCRIPTION
Mock server processes ignored SIGTERM because the shutdown() handler deadlocked with serve_forever() in the same thread, so interrupted or failed test runs leaked servers indefinitely. The helper now escalates to SIGKILL after a grace period and reports the termination result.

- Remove the deadlocking SIGTERM handler from mock_openai.py.
- Escalate stop() to SIGKILL and return the termination result.
- Add a regression test that starts a server and asserts stop reaps the process.