### PR TITLE
feat(registry): add Novita as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Choose a provider:
   or provide an existing `ANTHROPIC_OAUTH_TOKEN`.
 - Run `:NeoagentLogin deepseek` to store a DeepSeek API key, or set
   `DEEPSEEK_API_KEY` before starting Neovim.
+- Run `:NeoagentLogin novita` to store a Novita API key, or set
+  `NOVITA_API_KEY` before starting Neovim.
 - Run `:NeoagentLogin zai` to store a Z.AI API key, or set `ZAI_API_KEY`
   before starting Neovim. The credential enables both the metered API and
   global Coding Plan catalogs.
@@ -86,6 +88,15 @@ To use DeepSeek by default, replace `default_model` with:
 default_model = {
   provider = "deepseek",
   model = "deepseek-v4-flash",
+}
+```
+
+To use Novita by default, replace `default_model` with:
+
+```lua
+default_model = {
+  provider = "novita",
+  model = "moonshotai/kimi-k3",
 }
 ```
 

--- a/doc/neoagent.txt
+++ b/doc/neoagent.txt
@@ -76,6 +76,8 @@ The default registry contains these provider IDs:
                      `ANTHROPIC_OAUTH_TOKEN`.
   deepseek           DeepSeek API; `:NeoagentLogin deepseek` or
                      `DEEPSEEK_API_KEY`.
+  novita             Novita API; `:NeoagentLogin novita` or
+                     `NOVITA_API_KEY`.
   zai                Z.AI API and Coding Plan; `:NeoagentLogin zai` or
                      `ZAI_API_KEY`.
   zai-coding-plan    Z.AI Coding Plan models using the same `zai` credential.

--- a/lua/neoagent/config.lua
+++ b/lua/neoagent/config.lua
@@ -20,6 +20,7 @@ local defaults = {
     methods = {
       openai = api_key.new({ name = "OpenAI API key" }),
       deepseek = api_key.new({ name = "DeepSeek API key" }),
+      novita = api_key.new({ name = "Novita API key" }),
       zai = api_key.new({ name = "Z.AI API key" }),
       anthropic = api_key.new({
         name = "Anthropic API key",

--- a/lua/neoagent/registry.lua
+++ b/lua/neoagent/registry.lua
@@ -7,6 +7,7 @@ local defaults = {
   openai = openai.openai,
   ["openai-codex"] = openai["openai-codex"],
   deepseek = require("neoagent.registry.deepseek"),
+  novita = require("neoagent.registry.novita"),
   zai = require("neoagent.registry.zai"),
   ["zai-coding-plan"] = require("neoagent.registry.zai_coding_plan"),
   anthropic = require("neoagent.registry.anthropic"),

--- a/lua/neoagent/registry/novita.lua
+++ b/lua/neoagent/registry/novita.lua
@@ -1,0 +1,21 @@
+local models = {
+  ["moonshotai/kimi-k3"] = {
+    context_window = 1048576,
+    max_output_tokens = 1048576,
+    input = { "text", "image" },
+  },
+  ["zai-org/glm-5.2"] = { context_window = 1048576, max_output_tokens = 131072 },
+  ["deepseek/deepseek-v4-flash-0731"] = { context_window = 1048576, max_output_tokens = 393216 },
+}
+
+for _, model in pairs(models) do
+  model.input = model.input or { "text" }
+end
+
+return {
+  api = "openai-completions",
+  base_url = "https://api.novita.ai/openai",
+  api_key = function() return vim.env.NOVITA_API_KEY end,
+  auth = "novita",
+  models = models,
+}

--- a/tests/unit/config_models_spec.lua
+++ b/tests/unit/config_models_spec.lua
@@ -9,6 +9,7 @@ end
 describe("neoagent configuration and model resolution", function()
   local original_openai_key
   local original_deepseek_key
+  local original_novita_key
   local original_zai_key
   local original_anthropic_key
   local original_anthropic_oauth_token
@@ -17,11 +18,13 @@ describe("neoagent configuration and model resolution", function()
     config._reset()
     original_openai_key = vim.env.OPENAI_API_KEY
     original_deepseek_key = vim.env.DEEPSEEK_API_KEY
+    original_novita_key = vim.env.NOVITA_API_KEY
     original_zai_key = vim.env.ZAI_API_KEY
     original_anthropic_key = vim.env.ANTHROPIC_API_KEY
     original_anthropic_oauth_token = vim.env.ANTHROPIC_OAUTH_TOKEN
     vim.env.OPENAI_API_KEY = nil
     vim.env.DEEPSEEK_API_KEY = nil
+    vim.env.NOVITA_API_KEY = nil
     vim.env.ZAI_API_KEY = nil
     vim.env.ANTHROPIC_API_KEY = nil
     vim.env.ANTHROPIC_OAUTH_TOKEN = nil
@@ -31,6 +34,7 @@ describe("neoagent configuration and model resolution", function()
     config._reset()
     vim.env.OPENAI_API_KEY = original_openai_key
     vim.env.DEEPSEEK_API_KEY = original_deepseek_key
+    vim.env.NOVITA_API_KEY = original_novita_key
     vim.env.ZAI_API_KEY = original_zai_key
     vim.env.ANTHROPIC_API_KEY = original_anthropic_key
     vim.env.ANTHROPIC_OAUTH_TOKEN = original_anthropic_oauth_token
@@ -295,6 +299,30 @@ describe("neoagent configuration and model resolution", function()
       .. "(tool image omitted: model does not support images)",
       request.body.messages[3].content)
     assert.are.equal(3, #request.body.messages)
+    assert.are.same({ "text" }, model.input)
+  end)
+
+  it("resolves the built-in Novita catalog and request profile", function()
+    vim.env.NOVITA_API_KEY = "novita-key"
+    config.setup({})
+
+    local provider = config.get().providers.novita
+    assert.are.equal("openai-completions", provider.api)
+    assert.are.equal("novita", provider.auth)
+    assert.are.equal("https://api.novita.ai/openai", provider.base_url)
+    local available = assert(models.available())
+    assert.is_true(vim.tbl_contains(available, "novita/moonshotai/kimi-k3"))
+    assert.is_true(vim.tbl_contains(available, "novita/zai-org/glm-5.2"))
+    assert.are.equal(1048576, provider.models["moonshotai/kimi-k3"].context_window)
+    assert.are.equal(131072, provider.models["zai-org/glm-5.2"].max_output_tokens)
+
+    local model = models.resolve("novita", "zai-org/glm-5.2")
+    local request = model._model:_request({
+      messages = { { role = "user", content = { { type = "text", text = "hi" } } } },
+      tools = {},
+    })
+    assert.are.equal("https://api.novita.ai/openai/chat/completions", request.url)
+    assert.are.equal("Bearer novita-key", request.headers.Authorization)
     assert.are.same({ "text" }, model.input)
   end)
 


### PR DESCRIPTION

## Summary

Adds Novita as a built-in provider, following the same composition as
DeepSeek and Z.AI: an OpenAI Chat Completions-compatible entry with its
own catalog and an `api_key` auth method reading `NOVITA_API_KEY`.

## Changes

- Add `lua/neoagent/registry/novita.lua` with a catalog of three current
  flagship chat models (`moonshotai/kimi-k3`, `zai-org/glm-5.2`,
  `deepseek/deepseek-v4-flash-0731`), including context windows and max
  output tokens verified against the live `/openai/v1/models` response.
- Register `novita` in the default provider registry and its auth
  method in the built-in auth configuration.
- Document the provider in `README.md` and `doc/neoagent.txt` alongside
  the other built-in providers.
- Cover catalog resolution and request construction in
  `tests/unit/config_models_spec.lua`.

## Verification

- `make test-unit`: 25 passed, 2 pre-existing failures unrelated to this
  change (`tests/unit/tools_spec.lua` ENOENT on `rg`/`fd`, reproduced
  identically on `master`).
- `make test`: 276 passed, same 2 pre-existing failures, no regressions.
- Live catalog check: `GET https://api.novita.ai/openai/v1/models`
  returns 307 models including `moonshotai/kimi-k3`.
- Smoke test through the provider's real request path: model
  `moonshotai/kimi-k3`, stop reason `stop`, usage present, response text
  as expected.
