### PR TITLE
test(images): align reference width with captured cells

### DIFF
--- a/tests/terminal/image_harness.py
+++ b/tests/terminal/image_harness.py
@@ -433,8 +433,9 @@ def run_case(backend, terminal_kind, terminal, nvim, importer, image_tool,
                     raise RuntimeError(
                         f"{name} reference image is outside the capture: "
                         f"{reference_bounds}")
-                expected_width = round(
-                    reference_layer["image"]["width"] * cells["width"])
+                expected_width = (
+                    reference_layer["image"]["width"]
+                    * screen_cells["width"])
                 if abs((right - left) - expected_width) > 1:
                     raise RuntimeError(
                         f"{name} reference image width is {right - left}px, "


### PR DESCRIPTION
Compute the expected reference width from the same rasterized cell size used to derive screenshot bounds.

- Accept fractional terminal pixel metadata without false mismatches.
- Preserve clipping detection for the reference image.